### PR TITLE
Support only Python 3.11+

### DIFF
--- a/protovalidate/internal/constraints.py
+++ b/protovalidate/internal/constraints.py
@@ -249,7 +249,7 @@ class ConstraintRules:
 class CelConstraintRules(ConstraintRules):
     """A constraint that has rules written in CEL."""
 
-    _runners: list[typing.Tuple[celpy.Runner, expression_pb2.Constraint | private_pb2.Constraint]]
+    _runners: list[tuple[celpy.Runner, expression_pb2.Constraint | private_pb2.Constraint]]
     _rules_cel: celtypes.Value = None
 
     def __init__(self, rules: message.Message | None):
@@ -261,7 +261,7 @@ class CelConstraintRules(ConstraintRules):
         self, ctx: ConstraintContext, field_name: str, activation: dict[str, typing.Any], *, for_key: bool = False
     ):
         activation["rules"] = self._rules_cel
-        activation["now"] = celtypes.TimestampType(datetime.datetime.now(tz=datetime.timezone.utc))
+        activation["now"] = celtypes.TimestampType(datetime.datetime.now(tz=datetime.UTC))
         for runner, constraint in self._runners:
             result = runner.evaluate(activation)
             if isinstance(result, celtypes.BoolType):
@@ -364,8 +364,8 @@ class FieldConstraintRules(CelConstraintRules):
 class AnyConstraintRules(FieldConstraintRules):
     """Rules for an Any field."""
 
-    _in: typing.List[str] = []  # noqa: RUF012
-    _not_in: typing.List[str] = []  # noqa: RUF012
+    _in: list[str] = []  # noqa: RUF012
+    _not_in: list[str] = []  # noqa: RUF012
 
     def __init__(
         self,

--- a/protovalidate/internal/extra_func.py
+++ b/protovalidate/internal/extra_func.py
@@ -60,7 +60,7 @@ def validate_email(addr):
 
 
 def is_ip(val: celtypes.Value, version: celtypes.Value | None = None) -> celpy.Result:
-    if not isinstance(val, (celtypes.BytesType, celtypes.StringType)):
+    if not isinstance(val, celtypes.BytesType | celtypes.StringType):
         msg = "invalid argument, expected string or bytes"
         raise celpy.EvalError(msg)
     try:

--- a/protovalidate/internal/string_format.py
+++ b/protovalidate/internal/string_format.py
@@ -152,7 +152,7 @@ class StringFormat:
         return celtypes.StringType(arg)
 
     def format_value(self, arg: celtypes.Value) -> celpy.Result:
-        if isinstance(arg, (celtypes.StringType, str)):
+        if isinstance(arg, celtypes.StringType | str):
             return celtypes.StringType(quote(arg))
         if isinstance(arg, celtypes.UintType):
             return celtypes.StringType(arg)

--- a/protovalidate/validator.py
+++ b/protovalidate/validator.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typing
-
 from google.protobuf import message
 
 from buf.validate import expression_pb2  # type: ignore
@@ -100,7 +98,7 @@ class ValidationError(ValueError):
         super().__init__(msg)
         self.violations = violations
 
-    def errors(self) -> typing.List[expression_pb2.Violation]:
+    def errors(self) -> list[expression_pb2.Violation]:
         """
         Returns the validation errors as a simple Python list, rather than the
         Protobuf-specific collection type used by Violations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Protocol Buffer Validation for Python"
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["validate", "protobuf", "protocol buffer"]
-requires-python = ">=3.7"
+requires-python = ">=3.11"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: Apache Software License",
@@ -26,11 +26,11 @@ Issues = "https://github.com/bufbuild/protovalidate-python/issues"
 source = "vcs"
 
 [tool.black]
-target-version = ["py37"]
+target-version = ["py311"]
 line-length = 120
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py311"
 line-length = 120
 select = [
   "A",


### PR DESCRIPTION
Despite what `pyproject.toml` says, this project relies on PEP-604 and only works with Python >= 3.10. As a first step, this PR makes that explicit.

Fixes #89.
