### PR TITLE
Add explicit Python 3.13 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,8 @@
-name: Upload PyPi Release
+name: Upload PyPI Release
 
 on:
   release:
     types: [published]
-
-env:
-  PYTHON_VERSION: '3.7.17'
 
 jobs:
   build:
@@ -13,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
-    strategy:
-      matrix:
-        python-version: [ "3.11" ]
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -25,10 +19,10 @@ jobs:
         run: |
           VERSION=${{github.head_ref}}
           echo "VERSION=${VERSION##*/}" >> $GITHUB_ENV
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
       - name: Install pypa/build
         run: |
           python -m pip install build
@@ -39,7 +33,7 @@ jobs:
           path: dist/
 
   publish:
-    name: Publish on PyPi
+    name: Publish on PyPI
     runs-on: ubuntu-latest
     environment:
       name: release
@@ -56,7 +50,7 @@ jobs:
           name: package
           path: dist
 
-      - name: Publish on PyPi
+      - name: Publish on PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,12 @@ license = { file = "LICENSE" }
 keywords = ["validate", "protobuf", "protocol buffer"]
 requires-python = ">=3.8"
 classifiers = [
-  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
* Bumps matrices to include 3.13
* Drop matrix from release workflow; use latest to release
* Add individual trove classifiers for each supported version