### PR TITLE
Drop exceptiongroup/tomli from dev-dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,8 +12,6 @@ pytest = "*"
 mypy = "*"
 ruff = "*"
 types-protobuf = "*"
-exceptiongroup = "*"
-tomli = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9aa81c1d0ac01cfb87161aae0a3225ec156138188d7768f23cc7baf44f43444e"
+            "sha256": "e254d354c9ff664580a2ca3594d2fc669d3923a9700dcfbd325e4dcc728d273e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -286,15 +286,6 @@
         }
     },
     "develop": {
-        "exceptiongroup": {
-            "hashes": [
-                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
-                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==1.2.2"
-        },
         "iniconfig": {
             "hashes": [
                 "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
@@ -352,11 +343,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
-                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.1"
+            "version": "==24.2"
         },
         "pluggy": {
             "hashes": [
@@ -399,15 +390,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==0.7.4"
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38",
-                "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==2.0.2"
         },
         "types-protobuf": {
             "hashes": [


### PR DESCRIPTION
I don't believe we need to specify these separately...
