### PR TITLE
Add rule and field value to violations

### DIFF
--- a/protovalidate/internal/constraints.py
+++ b/protovalidate/internal/constraints.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import datetime
 import typing
 
@@ -293,27 +294,13 @@ class ConstraintRules:
         ctx.add(Violation(constraint_id="unimplemented", message="Unimplemented"))
 
 
+@dataclasses.dataclass
 class CelRunner:
     runner: celpy.Runner
     constraint: validate_pb2.Constraint
-    rule_value: typing.Optional[typing.Any]
-    rule_cel: typing.Optional[celtypes.Value]
-    rule_path: typing.Optional[validate_pb2.FieldPath]
-
-    def __init__(
-        self,
-        *,
-        runner: celpy.Runner,
-        constraint: validate_pb2.Constraint,
-        rule_value: typing.Optional[typing.Any] = None,
-        rule_cel: typing.Optional[celtypes.Value] = None,
-        rule_path: typing.Optional[validate_pb2.FieldPath] = None,
-    ):
-        self.runner = runner
-        self.constraint = constraint
-        self.rule_value = rule_value
-        self.rule_cel = rule_cel
-        self.rule_path = rule_path
+    rule_value: typing.Optional[typing.Any] = None
+    rule_cel: typing.Optional[celtypes.Value] = None
+    rule_path: typing.Optional[validate_pb2.FieldPath] = None
 
 
 class CelConstraintRules(ConstraintRules):

--- a/protovalidate/internal/constraints.py
+++ b/protovalidate/internal/constraints.py
@@ -260,7 +260,7 @@ class ConstraintContext:
     def violations(self) -> list[Violation]:
         return self._violations
 
-    def add(self, violation: list[Violation]):
+    def add(self, violation: Violation):
         self._violations.append(violation)
 
     def add_errors(self, other_ctx):

--- a/protovalidate/validator.py
+++ b/protovalidate/validator.py
@@ -101,9 +101,9 @@ class ValidationError(ValueError):
     An error raised when a message fails to validate.
     """
 
-    _violations: list[Violation]
+    _violations: list[_constraints.Violation]
 
-    def __init__(self, msg: str, violations: list[validate_pb2.Violations]):
+    def __init__(self, msg: str, violations: list[_constraints.Violation]):
         super().__init__(msg)
         self._violations = violations
 

--- a/protovalidate/validator.py
+++ b/protovalidate/validator.py
@@ -103,7 +103,7 @@ class ValidationError(ValueError):
 
     _violations: list[Violation]
 
-    def __init__(self, msg: str, violations: list[Violations]):
+    def __init__(self, msg: str, violations: list[validate_pb2.Violations]):
         super().__init__(msg)
         self._violations = violations
 

--- a/protovalidate/validator.py
+++ b/protovalidate/validator.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import typing
+
 from google.protobuf import message
 
 from buf.validate import validate_pb2  # type: ignore
@@ -20,6 +22,7 @@ from protovalidate.internal import extra_func, field_path
 
 CompilationError = _constraints.CompilationError
 Violations = validate_pb2.Violations
+Violation = _constraints.Violation
 
 
 class Validator:
@@ -54,7 +57,7 @@ class Validator:
             ValidationError: If the message is invalid.
         """
         violations = self.collect_violations(message, fail_fast=fail_fast)
-        if violations.violations:
+        if len(violations) > 0:
             msg = f"invalid {message.DESCRIPTOR.name}"
             raise ValidationError(msg, violations)
 
@@ -63,8 +66,8 @@ class Validator:
         message: message.Message,
         *,
         fail_fast: bool = False,
-        into: validate_pb2.Violations = None,
-    ) -> validate_pb2.Violations:
+        into: typing.Optional[list[Violation]] = None,
+    ) -> list[Violation]:
         """
         Validates the given message against the static constraints defined in
         the message's descriptor. Compared to validate, collect_violations is
@@ -84,12 +87,12 @@ class Validator:
             constraint.validate(ctx, message)
             if ctx.done:
                 break
-        for violation in ctx.violations.violations:
-            if violation.HasField("field"):
-                violation.field.elements.reverse()
-            if violation.HasField("rule"):
-                violation.rule.elements.reverse()
-            violation.field_path = field_path.string(violation.field)
+        for violation in ctx.violations:
+            if violation.proto.HasField("field"):
+                violation.proto.field.elements.reverse()
+            if violation.proto.HasField("rule"):
+                violation.proto.rule.elements.reverse()
+            violation.proto.field_path = field_path.string(violation.proto.field)
         return ctx.violations
 
 
@@ -98,15 +101,25 @@ class ValidationError(ValueError):
     An error raised when a message fails to validate.
     """
 
-    violations: validate_pb2.Violations
+    _violations: list[Violation]
 
-    def __init__(self, msg: str, violations: validate_pb2.Violations):
+    def __init__(self, msg: str, violations: list[Violations]):
         super().__init__(msg)
-        self.violations = violations
+        self._violations = violations
 
-    def errors(self) -> list[validate_pb2.Violation]:
+    def to_proto(self) -> validate_pb2.Violations:
         """
-        Returns the validation errors as a simple Python list, rather than the
+        Provides the Protobuf form of the validation errors.
+        """
+        result = validate_pb2.Violations()
+        for violation in self._violations:
+            result.violations.append(violation.proto)
+        return result
+
+    @property
+    def violations(self) -> list[Violation]:
+        """
+        Provides the validation errors as a simple Python list, rather than the
         Protobuf-specific collection type used by Violations.
         """
-        return list(self.violations.violations)
+        return self._violations

--- a/tests/conformance/runner.py
+++ b/tests/conformance/runner.py
@@ -62,7 +62,9 @@ def run_test_case(tc: typing.Any, result: typing.Optional[harness_pb2.TestResult
         result = harness_pb2.TestResult()
     # Run the validator
     try:
-        protovalidate.collect_violations(tc, into=result.validation_error)
+        violations = protovalidate.collect_violations(tc)
+        for violation in violations:
+            result.validation_error.violations.append(violation.proto)
         if len(result.validation_error.violations) == 0:
             result.success = True
     except celpy.CELEvalError as e:

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -23,23 +23,27 @@ class TestValidate(unittest.TestCase):
         msg = numbers_pb2.DoubleFinite()
         msg.val = float("-inf")
         violations = protovalidate.collect_violations(msg)
-        self.assertEqual(len(violations.violations), 1)
-        self.assertEqual(violations.violations[0].constraint_id, "double.finite")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].proto.constraint_id, "double.finite")
+        self.assertEqual(violations[0].field_value, msg.val)
+        self.assertEqual(violations[0].rule_value, True)
 
     def test_map_key(self):
         msg = maps_pb2.MapKeys()
         msg.val[1] = "a"
         violations = protovalidate.collect_violations(msg)
-        self.assertEqual(len(violations.violations), 1)
-        self.assertEqual(violations.violations[0].field_path, "val[1]")
-        self.assertEqual(violations.violations[0].for_key, True)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].proto.field_path, "val[1]")
+        self.assertEqual(violations[0].proto.for_key, True)
+        self.assertEqual(violations[0].field_value, 1)
+        self.assertEqual(violations[0].rule_value, 0)
 
     def test_sfixed64(self):
         msg = numbers_pb2.SFixed64ExLTGT(val=11)
         protovalidate.validate(msg)
 
         violations = protovalidate.collect_violations(msg)
-        self.assertEqual(len(violations.violations), 0)
+        self.assertEqual(len(violations), 0)
 
     def test_oneofs(self):
         msg1 = oneofs_pb2.Oneof()
@@ -52,7 +56,7 @@ class TestValidate(unittest.TestCase):
 
         violations = protovalidate.collect_violations(msg1)
         protovalidate.collect_violations(msg2, into=violations)
-        assert len(violations.violations) == 0
+        assert len(violations) == 0
 
     def test_repeated(self):
         msg = repeated_pb2.RepeatedEmbedSkip()
@@ -60,23 +64,23 @@ class TestValidate(unittest.TestCase):
         protovalidate.validate(msg)
 
         violations = protovalidate.collect_violations(msg)
-        assert len(violations.violations) == 0
+        assert len(violations) == 0
 
     def test_maps(self):
         msg = maps_pb2.MapMinMax()
         try:
             protovalidate.validate(msg)
         except protovalidate.ValidationError as e:
-            assert len(e.errors()) == 1
-            assert len(e.violations.violations) == 1
+            assert len(e.violations) == 1
+            assert len(e.to_proto().violations) == 1
             assert str(e) == "invalid MapMinMax"
 
         violations = protovalidate.collect_violations(msg)
-        assert len(violations.violations) == 1
+        assert len(violations) == 1
 
     def test_timestamp(self):
         msg = wkt_timestamp_pb2.TimestampGTNow()
         protovalidate.validate(msg)
 
         violations = protovalidate.collect_violations(msg)
-        assert len(violations.violations) == 0
+        assert len(violations) == 0


### PR DESCRIPTION
Adds the ability to access the captured rule and field value from a `Violation`.

**This is a breaking change.** The API changes in the following ways:
- `ValidationError` has changed:
    - Old accesses to `ValidationError.violations` should call `ValidationError.to_proto()` instead, to get a `buf.validate.Violations` message.
    - `ValidationError.errors` was removed. Switch to using `ValidationError.violations` instead.
    - `ValidationError.violations` provides a list of the new `Violation` wrapper type instead of a list of `buf.validate.Violation`.
    -  The new `Violation` wrapper type contains the `buf.validate.Violation` message under the `proto` field, as well as `field_value` and `rule_value` properties that capture the field and rule values, respectively.
- `Validator.collect_violations` now operates on and returns `list[Violation]` instead of the protobuf `buf.validate.Violations` message.

This API mirrors the changes being made in protovalidate-go in https://github.com/bufbuild/protovalidate-go/pull/154.