### PR TITLE
Fix README cel expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ message Transaction {
   string price = 4 [(buf.validate.field).cel = {
     id: "transaction.price",
     message: "price must be positive and include a valid currency symbol ($ or £)",
-    expression: "(this.startswith('$') or this.startswith('£')) and float(this[1:]) > 0"
+    expression: "(this.startsWith('$') || this.startsWith('£')) && double(this.substring(1)) > 0"
   }];
 
   option (buf.validate.message).cel = {


### PR DESCRIPTION
Matches [`protovalidate-go`'s usage instructions](https://github.com/bufbuild/protovalidate-go?tab=readme-ov-file#usage).

Fixes #229.