### PR TITLE
Add PEP 561 type support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
+  "Typing :: Typed",
 ]
 dynamic = ["version"]
 dependencies = ["protobuf", "cel-python"]


### PR DESCRIPTION
Adds an empty `py.typed` file at the root of the source tree, and adds the [canonical typing classifier][1] to the list of classifiers.

Closes #242.

[1]: https://pypi.org/classifiers/