### PR TITLE
Pass `--strict_message` conformance (minus duration/timestamp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export PATH := $(BIN):$(PATH)
 export GOBIN := $(abspath $(BIN))
 # Set to use a different Python interpreter. For example, `PYTHON=python make test`.
 PYTHON ?= python3
-CONFORMANCE_ARGS ?= --strict --expected_failures=tests/conformance/nonconforming.yaml --timeout 10s
+CONFORMANCE_ARGS ?= --strict --strict_message --expected_failures=tests/conformance/nonconforming.yaml --timeout 10s
 ADD_LICENSE_HEADER := $(BIN)/license-header \
 		--license-type apache \
 		--copyright-holder "Buf Technologies, Inc." \

--- a/protovalidate/internal/string_format.py
+++ b/protovalidate/internal/string_format.py
@@ -146,9 +146,19 @@ class StringFormat:
         if isinstance(arg, celtypes.StringType):
             return arg
         if isinstance(arg, celtypes.BytesType):
-            return celtypes.StringType(arg.hex())
+            return celtypes.StringType(arg)
         if isinstance(arg, celtypes.ListType):
             return self.format_list(arg)
+        if isinstance(arg, celtypes.BoolType):
+            # True -> true
+            return celtypes.StringType(str(arg).lower())
+        if isinstance(arg, celtypes.DoubleType):
+            return celtypes.StringType(f"{arg:.0f}")
+        if isinstance(arg, celtypes.TimestampType):
+            base = arg.isoformat()
+            if arg.getMilliseconds() != 0:
+                base = arg.isoformat(timespec="milliseconds")
+            return celtypes.StringType(base.removesuffix("+00:00") + "Z")
         return celtypes.StringType(arg)
 
     def format_value(self, arg: celtypes.Value) -> celpy.Result:
@@ -156,6 +166,10 @@ class StringFormat:
             return celtypes.StringType(quote(arg))
         if isinstance(arg, celtypes.UintType):
             return celtypes.StringType(arg)
+        if isinstance(arg, celtypes.DurationType):
+            return celtypes.StringType(f'duration("{arg.seconds + (arg.microseconds // 1e6):.0f}s")')
+        if isinstance(arg, celtypes.DoubleType):
+            return celtypes.StringType(f"{arg:f}")
         return self.format_string(arg)
 
     def format_list(self, arg: celtypes.ListType) -> celpy.Result:

--- a/protovalidate/internal/string_format.py
+++ b/protovalidate/internal/string_format.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from decimal import Decimal
+
 import celpy  # type: ignore
 from celpy import celtypes  # type: ignore
-from decimal import Decimal
 
 QUOTE_TRANS = str.maketrans(
     {

--- a/protovalidate/internal/string_format.py
+++ b/protovalidate/internal/string_format.py
@@ -14,6 +14,7 @@
 
 import celpy  # type: ignore
 from celpy import celtypes  # type: ignore
+from decimal import Decimal
 
 QUOTE_TRANS = str.maketrans(
     {
@@ -154,6 +155,8 @@ class StringFormat:
             return celtypes.StringType(str(arg).lower())
         if isinstance(arg, celtypes.DoubleType):
             return celtypes.StringType(f"{arg:.0f}")
+        if isinstance(arg, celtypes.DurationType):
+            return celtypes.StringType(self._format_duration(arg))
         if isinstance(arg, celtypes.TimestampType):
             base = arg.isoformat()
             if arg.getMilliseconds() != 0:
@@ -167,7 +170,7 @@ class StringFormat:
         if isinstance(arg, celtypes.UintType):
             return celtypes.StringType(arg)
         if isinstance(arg, celtypes.DurationType):
-            return celtypes.StringType(f'duration("{arg.seconds + (arg.microseconds // 1e6):.0f}s")')
+            return celtypes.StringType(f'duration("{self._format_duration(arg)}")')
         if isinstance(arg, celtypes.DoubleType):
             return celtypes.StringType(f"{arg:f}")
         return self.format_string(arg)
@@ -180,6 +183,9 @@ class StringFormat:
             result += self.format_value(arg[i])
         result += "]"
         return celtypes.StringType(result)
+
+    def _format_duration(self, arg: celtypes.DurationType) -> celpy.Result:
+        return f"{arg.seconds + Decimal(arg.microseconds) / Decimal(1_000_000):f}s"
 
 
 _default_format = StringFormat("en_US")

--- a/tests/conformance/nonconforming.yaml
+++ b/tests/conformance/nonconforming.yaml
@@ -3,12 +3,7 @@
 standard_constraints/well_known_types/duration:
  - gte_lte/invalid/above
  - lte/invalid
- - gte/invalid
- - gt/invalid
- - in/invalid
- - "not in/valid"
+ - not in/valid
 standard_constraints/well_known_types/timestamp:
  - gte_lte/invalid/above
  - lte/invalid
-standard_constraints/repeated:
- - duration/gte/invalid

--- a/tests/conformance/nonconforming.yaml
+++ b/tests/conformance/nonconforming.yaml
@@ -1,8 +1,14 @@
 # celpy doesn't support nano seconds
+# ref: https://github.com/cloud-custodian/cel-python/issues/43
 standard_constraints/well_known_types/duration:
  - gte_lte/invalid/above
  - lte/invalid
- - not in/valid
+ - gte/invalid
+ - gt/invalid
+ - in/invalid
+ - "not in/valid"
 standard_constraints/well_known_types/timestamp:
  - gte_lte/invalid/above
  - lte/invalid
+standard_constraints/repeated:
+ - duration/gte/invalid


### PR DESCRIPTION
We can't currently pass the conformance tests involving duration+timestamp types, as cel-python does not support nanoseconds in its duration implementation (linked issue). Otherwise, this gets us to a conformant spot.

Related to #255.