### PR TITLE
Propose docstring style for repo

### DIFF
--- a/protovalidate/internal/extra_func.py
+++ b/protovalidate/internal/extra_func.py
@@ -145,7 +145,7 @@ def is_ip_prefix(val: celtypes.Value, *args) -> celpy.Result:
 
 
 def is_email(string: celtypes.Value) -> celpy.Result:
-    """Validate whether string is a valid email address.
+    """Return true if the string is an email address, for example "foo@example.com".
 
     Conforms to the definition for a valid email address from the HTML standard.
     Note that this standard willfully deviates from RFC 5322, which allows many
@@ -161,7 +161,7 @@ def is_email(string: celtypes.Value) -> celpy.Result:
 
 
 def is_uri(string: celtypes.Value) -> celpy.Result:
-    """Validate whether string is a valid URI.
+    """Return true if the string is a URI, for example "https://example.com/foo/bar?baz=quux#frag".
 
     URI is defined in the internet standard RFC 3986.
     Zone Identifiers in IPv6 address literals are supported (RFC 6874).
@@ -175,7 +175,8 @@ def is_uri(string: celtypes.Value) -> celpy.Result:
 
 
 def is_uri_ref(string: celtypes.Value) -> celpy.Result:
-    """Validate whether string is a valid URI reference.
+    """Return true if the string is a URI Reference - a URI such as "https://example.com/foo/bar?baz=quux#frag" or
+    a Relative Reference such as "./foo/bar?query".
 
     URI, URI Reference, and Relative Reference are defined in the internet standard RFC 3986.
     Zone Identifiers in IPv6 address literals are supported (RFC 6874).

--- a/protovalidate/internal/extra_func.py
+++ b/protovalidate/internal/extra_func.py
@@ -152,16 +152,7 @@ def is_email(string: celtypes.Value) -> celpy.Result:
     unexpected forms of email addresses and will easily match a typographical
     error.
 
-    Args:
-        string (celTypes.Value): The string to validate.
-
-    Returns:
-        True if the string is an email address, for example "foo@example.com". False otherwise.
-
-    Raises:
-        celpy.CELEvalError: If string is not an instance of celtypes.StringType.
     """
-
     if not isinstance(string, celtypes.StringType):
         msg = "invalid argument, expected string"
         raise celpy.CELEvalError(msg)
@@ -175,16 +166,7 @@ def is_uri(string: celtypes.Value) -> celpy.Result:
     URI is defined in the internet standard RFC 3986.
     Zone Identifiers in IPv6 address literals are supported (RFC 6874).
 
-    Args:
-        string (celTypes.Value): The string to validate.
-
-    Returns:
-        True if the string is a URI, for example "https://example.com/foo/bar?baz=quux#frag". False otherwise.
-
-    Raises:
-        celpy.CELEvalError: If string is not an instance of celtypes.StringType.
     """
-
     if not isinstance(string, celtypes.StringType):
         msg = "invalid argument, expected string"
         raise celpy.CELEvalError(msg)
@@ -198,17 +180,7 @@ def is_uri_ref(string: celtypes.Value) -> celpy.Result:
     URI, URI Reference, and Relative Reference are defined in the internet standard RFC 3986.
     Zone Identifiers in IPv6 address literals are supported (RFC 6874).
 
-    Args:
-        string (celTypes.Value): The string to validate.
-
-    Returns:
-        True if the string is a URI Reference - a URI such as "https://example.com/foo/bar?baz=quux#frag"
-        or a Relative Reference such as "./foo/bar?query". False otherwise.
-
-    Raises:
-        celpy.CELEvalError: If string is not an instance of celtypes.StringType.
     """
-
     if not isinstance(string, celtypes.StringType):
         msg = "invalid argument, expected string"
         raise celpy.CELEvalError(msg)
@@ -266,27 +238,14 @@ def unique(val: celtypes.Value) -> celpy.Result:
 
 
 class Uri:
-    """Uri is a class used to parse a given string to determine if it is a valid URI or URI reference.
-
-    Callers can validate a string by constructing an instance of this class and then calling one of its
-    public methods:
-        uri()
-        uri_reference()
-
-    Each method will return True or False depending on whether it passes validation.
-    """
+    """Uri is a class used to parse a given string to determine if it is a valid URI or URI reference."""
 
     _string: str
     _index: int
     _pct_encoded_found: bool
 
     def __init__(self, string: str):
-        """Initialize a URI validation class with a given string
-
-        Args:
-            string (str): String to validate as a URI or URI reference.
-        """
-
+        """Initialize a URI validation class with a given string."""
         super().__init__()
         self._string = string
         self._index = 0
@@ -296,9 +255,9 @@ class Uri:
 
         Method parses the rule:
 
-        URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-        """
+            URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
 
+        """
         start = self._index
         if not (self.__scheme() and self.__take(":") and self.__hier_part()):
             self._index = start
@@ -321,9 +280,9 @@ class Uri:
 
         Method parses the rule:
 
-        URI-reference = URI / relative-ref
-        """
+            URI-reference = URI / relative-ref
 
+        """
         return self.uri() or self.__relative_ref()
 
     def __hier_part(self) -> bool:
@@ -331,12 +290,12 @@ class Uri:
 
         Method parses the rule:
 
-        hier-part = "//" authority path-abempty.
-                  / path-absolute
-                  / path-rootless
-                  / path-empty
-        """
+            hier-part = "//" authority path-abempty.
+                      / path-absolute
+                      / path-rootless
+                      / path-empty
 
+        """
         start = self._index
         if self.__take("/") and self.__take("/") and self.__authority() and self.__path_abempty():
             return True
@@ -350,9 +309,9 @@ class Uri:
 
         Method parses the rule:
 
-        relative-ref = relative-part [ "?" query ] [ "#" fragment ]
-        """
+            relative-ref = relative-part [ "?" query ] [ "#" fragment ]
 
+        """
         start = self._index
         if not self.__relative_part():
             return False
@@ -376,12 +335,12 @@ class Uri:
 
         Method parses the rule:
 
-        relative-part = "//" authority path-abempty
-                      / path-absolute
-                      / path-noscheme
-                      / path-empty
-        """
+            relative-part = "//" authority path-abempty
+                          / path-absolute
+                          / path-noscheme
+                          / path-empty
 
+        """
         start = self._index
         if self.__take("/") and self.__take("/") and self.__authority() and self.__path_abempty():
             return True
@@ -395,11 +354,11 @@ class Uri:
 
         Method parses the rule:
 
-        scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+            scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 
         Terminated by ":".
-        """
 
+        """
         start = self._index
         if self.__alpha():
             while self.__alpha() or self.__digit() or self.__take("+") or self.__take("-") or self.__take("."):
@@ -416,11 +375,11 @@ class Uri:
 
         Method parses the rule:
 
-        authority = [ userinfo "@" ] host [ ":" port ]
+            authority = [ userinfo "@" ] host [ ":" port ]
 
         Lead by double slash ("") and terminated by "/", "?", "#", or end of URI.
-        """
 
+        """
         start = self._index
         if self.__userinfo():
             if not self.__take("@"):
@@ -448,8 +407,8 @@ class Uri:
         The authority component [...] is terminated by the next slash ("/"),
         question mark ("?"), or number sign ("#") character, or by the
         end of the URI.
-        """
 
+        """
         return (
             self._index >= len(self._string)
             or self._string[self._index] == "?"
@@ -462,11 +421,11 @@ class Uri:
 
         Method parses the rule:
 
-        userinfo = *( unreserved / pct-encoded / sub-delims / ":" )
+            userinfo = *( unreserved / pct-encoded / sub-delims / ":" )
 
         Terminated by "@" in authority.
-        """
 
+        """
         start = self._index
         while True:
             if self.__unreserved() or self.__pct_encoded() or self.__sub_delims() or self.__take(":"):
@@ -480,7 +439,7 @@ class Uri:
             return False
 
     def __check_host_pct_encoded(self, string: str) -> bool:
-        """Verify that string is correctly percent-encoded"""
+        """Verify that string is correctly percent-encoded."""
         try:
             # unquote defaults to 'UTF-8' encoding.
             urlparse.unquote(string, errors="strict")
@@ -494,9 +453,9 @@ class Uri:
 
         Method parses the rule:
 
-        host = IP-literal / IPv4address / reg-name.
-        """
+            host = IP-literal / IPv4address / reg-name.
 
+        """
         if self._index >= len(self._string):
             return False
 
@@ -522,11 +481,11 @@ class Uri:
 
         Method parses the rule:
 
-        port = *DIGIT
+            port = *DIGIT
 
         Terminated by end of authority.
-        """
 
+        """
         start = self._index
         while True:
             if self.__digit():
@@ -543,9 +502,9 @@ class Uri:
 
         Method parses the rule from RFC 6874:
 
-        IP-literal = "[" ( IPv6address / IPv6addrz / IPvFuture  ) "]"
-        """
+            IP-literal = "[" ( IPv6address / IPv6addrz / IPvFuture  ) "]"
 
+        """
         start = self._index
 
         if self.__take("["):
@@ -572,8 +531,8 @@ class Uri:
         Method parses the rule "IPv6address".
 
         Relies on the implementation of validate_ip.
-        """
 
+        """
         start = self._index
         while self.__hex_dig() or self.__take(":"):
             pass
@@ -589,9 +548,9 @@ class Uri:
 
         Method parses the rule from RFC 6874:
 
-        IPv6addrz = IPv6address "%25" ZoneID
-        """
+            IPv6addrz = IPv6address "%25" ZoneID
 
+        """
         start = self._index
         if self.__ipv6_address() and self.__take("%") and self.__take("2") and self.__take("5") and self.__zone_id():
             return True
@@ -605,9 +564,9 @@ class Uri:
 
         Method parses the rule from RFC 6874:
 
-        ZoneID = 1*( unreserved / pct-encoded )
-        """
+            ZoneID = 1*( unreserved / pct-encoded )
 
+        """
         start = self._index
         while self.__unreserved() or self.__pct_encoded():
             pass
@@ -624,9 +583,9 @@ class Uri:
 
         Method parses the rule:
 
-        IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
-        """
+            IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
 
+        """
         start = self._index
 
         if self.__take("v") and self.__hex_dig():
@@ -650,11 +609,11 @@ class Uri:
 
         Method parses the rule:
 
-        reg-name = *( unreserved / pct-encoded / sub-delims )
+            reg-name = *( unreserved / pct-encoded / sub-delims )
 
         Terminates on start of port (":") or end of authority.
-        """
 
+        """
         start = self._index
         while True:
             if self.__unreserved() or self.__pct_encoded() or self.__sub_delims():
@@ -676,8 +635,8 @@ class Uri:
 
         > The path is terminated by the first question mark ("?") or
         > number sign ("#") character, or by the end of the URI.
-        """
 
+        """
         return self._index >= len(self._string) or self._string[self._index] == "?" or self._string[self._index] == "#"
 
     def __path_abempty(self) -> bool:
@@ -685,11 +644,11 @@ class Uri:
 
         Method parses the rule:
 
-        path-abempty = *( "/" segment )
+            path-abempty = *( "/" segment )
 
         Terminated by end of path: "?", "#", or end of URI.
-        """
 
+        """
         start = self._index
         while self.__take("/") and self.__segment():
             pass
@@ -706,11 +665,11 @@ class Uri:
 
         Method parses the rule:
 
-        path-absolute = "/" [ segment-nz *( "/" segment ) ]
+            path-absolute = "/" [ segment-nz *( "/" segment ) ]
 
         Terminated by end of path: "?", "#", or end of URI.
-        """
 
+        """
         start = self._index
 
         if self.__take("/"):
@@ -730,11 +689,11 @@ class Uri:
 
         Method parses the rule:
 
-        path-noscheme = segment-nz-nc *( "/" segment )
+            path-noscheme = segment-nz-nc *( "/" segment )
 
         Terminated by end of path: "?", "#", or end of URI.
-        """
 
+        """
         start = self._index
         if self.__segment_nz_nc():
             while self.__take("/") and self.__segment():
@@ -752,11 +711,11 @@ class Uri:
 
         Method parses the rule:
 
-        path-rootless = segment-nz *( "/" segment )
+            path-rootless = segment-nz *( "/" segment )
 
         Terminated by end of path: "?", "#", or end of URI.
-        """
 
+        """
         start = self._index
 
         if self.__segment_nz():
@@ -775,11 +734,11 @@ class Uri:
 
         Method parses the rule:
 
-        path-empty = 0<pchar>
+            path-empty = 0<pchar>
 
         Terminated by end of path: "?", "#", or end of URI.
-        """
 
+        """
         return self.__is_path_end()
 
     def __segment(self) -> bool:
@@ -787,9 +746,9 @@ class Uri:
 
         Method parses the rule:
 
-        segment = *pchar
-        """
+            segment = *pchar
 
+        """
         while self.__pchar():
             pass
 
@@ -800,9 +759,9 @@ class Uri:
 
         Method parses the rule:
 
-        segment-nz = 1*pchar
-        """
+            segment-nz = 1*pchar
 
+        """
         start = self._index
 
         if self.__pchar():
@@ -820,10 +779,10 @@ class Uri:
 
         Method parses the rule:
 
-        segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
-                      ; non-zero-length segment without any colon ":"
-        """
+            segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+                          ; non-zero-length segment without any colon ":"
 
+        """
         start = self._index
 
         while self.__unreserved() or self.__pct_encoded() or self.__sub_delims() or self.__take("@"):
@@ -841,9 +800,9 @@ class Uri:
 
         Method parses the rule:
 
-        pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
-        """
+            pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
 
+        """
         return (
             self.__unreserved() or self.__pct_encoded() or self.__sub_delims() or self.__take(":") or self.__take("@")
         )
@@ -853,11 +812,11 @@ class Uri:
 
         Method parses the rule:
 
-        query = *( pchar / "/" / "?" )
+            query = *( pchar / "/" / "?" )
 
         Terminated by "#" or end of URI.
-        """
 
+        """
         start = self._index
 
         while True:
@@ -876,11 +835,11 @@ class Uri:
 
         Method parses the rule:
 
-        fragment = *( pchar / "/" / "?" )
+            fragment = *( pchar / "/" / "?" )
 
         Terminated by end of URI.
-        """
 
+        """
         start = self._index
 
         while True:
@@ -899,11 +858,11 @@ class Uri:
 
         Method parses the rule:
 
-        pct-encoded = "%" HEXDIG HEXDIG
+            pct-encoded = "%" HEXDIG HEXDIG
 
         Sets `_pct_encoded_found` to true if a valid triplet was found
-        """
 
+        """
         start = self._index
 
         if self.__take("%") and self.__hex_dig() and self.__hex_dig():
@@ -919,9 +878,9 @@ class Uri:
 
         Method parses the rule:
 
-        unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
-        """
+            unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
 
+        """
         return (
             self.__alpha()
             or self.__digit()
@@ -936,10 +895,10 @@ class Uri:
 
         Method parses the rule:
 
-        sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
-                    / "*" / "+" / "," / ";" / "="
-        """
+            sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+                        / "*" / "+" / "," / ";" / "="
 
+        """
         return (
             self.__take("!")
             or self.__take("$")
@@ -959,9 +918,9 @@ class Uri:
 
         Method parses the rule:
 
-        ALPHA =  %x41-5A / %x61-7A ; A-Z / a-z
-        """
+            ALPHA =  %x41-5A / %x61-7A ; A-Z / a-z
 
+        """
         if self._index >= len(self._string):
             return False
 
@@ -977,9 +936,9 @@ class Uri:
 
         Method parses the rule:
 
-        DIGIT = %x30-39  ; 0-9
-        """
+            DIGIT = %x30-39  ; 0-9
 
+        """
         if self._index >= len(self._string):
             return False
 
@@ -995,9 +954,9 @@ class Uri:
 
         Method parses the rule:
 
-        HEXDIG =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
-        """
+            HEXDIG =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 
+        """
         if self._index >= len(self._string):
             return False
 
@@ -1014,12 +973,7 @@ class Uri:
         """Take the given char at the current index.
 
         If char is at the current index, increment the index.
-
-        Returns:
-            True if char is at the current index. False if char is not at the
-            current index or the end of string has been reached.
         """
-
         if self._index >= len(self._string):
             return False
 


### PR DESCRIPTION
Here is a proposal for how to structure docstrings in protovalidate-python going forward (at least when porting the rest of the validation implementations). I think this strikes the right balance of adhering to best practices while not being onerous. 

* Functions being added to the library should get the bulk of the comment description in a docstring. No need to define `Args:`, `Raises:`, etc. though.
* Any other public function, class, etc. should preferably have docstrings, though not necessary.
* Be as succinct as possible while also keeping comments across implementations consistently worded.

For validation following an RFC / spec:
* Always include any relevant ABNF grammar and keep aligned.
* Indent grammar inside docstring.

One suggestion outside the scope of this PR might be to always have full docstring (`Args`, `Raises`, etc.) on any public method the user interacts with (i.e. stuff in `validator.py`)