### PR TITLE
Fix isEmail ignoring trailing newlines

### DIFF
--- a/protovalidate/internal/extra_func.py
+++ b/protovalidate/internal/extra_func.py
@@ -137,7 +137,7 @@ def cel_is_email(string: celtypes.Value) -> celpy.Result:
     if not isinstance(string, celtypes.StringType):
         msg = "invalid argument, expected string"
         raise celpy.CELEvalError(msg)
-    m = _email_regex.match(string) is not None
+    m = _email_regex.fullmatch(string) is not None
     return celtypes.BoolType(m)
 
 


### PR DESCRIPTION
`isEmail` incorrectly returns true for the input `foobar@example.com\n`. This happens because `$` will match a line ending even without the multiline flag with [re.match](https://docs.python.org/3/library/re.html#re.match). We need to use [re.fullmatch](https://docs.python.org/3/library/re.html#re.fullmatch) instead.
