### PR TITLE
Update to new logo

### DIFF
--- a/.github/buf-logo.svg
+++ b/.github/buf-logo.svg
@@ -1,1 +1,10 @@
-<svg width="100" height="101" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.144 78.583H0V.017h7.144v78.566ZM21.43 78.583h-7.143V.017h7.144v78.566ZM35.715 78.583H28.57V.017h7.144v78.566ZM50 78.583h-7.144V.017H50v78.566ZM64.286 78.583h-7.143V.017h7.143v78.566ZM78.576 78.583h-7.143V.017h7.143v78.566Z" fill="#77E1FF"/><path d="M28.576 100.018h-7.143V21.452h7.143v78.566ZM42.856 100.014h-7.143V21.448h7.143v78.566ZM57.142 100.018H50V21.452h7.144v78.566ZM71.433 100.014h-7.144V21.448h7.144v78.566ZM85.717 100.014h-7.144V21.448h7.144v78.566ZM99.999 100.018h-7.143V21.452h7.143v78.566Z" fill="#161EDE"/></svg>
+<svg width="85" height="80" viewBox="0 0 85 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="25.4114" y="20.7058" width="8.47059" height="59.2941" fill="#0E5DF5"/>
+<rect x="42.3533" y="20.7058" width="8.47059" height="59.2941" fill="#0E5DF5"/>
+<rect x="59.2942" y="20.7058" width="8.47059" height="59.2941" fill="#0E5DF5"/>
+<rect x="76.2352" y="20.7058" width="8.47059" height="59.2941" fill="#0E5DF5"/>
+<rect width="8.47059" height="59.2941" fill="#5FDCFF"/>
+<rect x="16.9409" width="8.47059" height="59.2941" fill="#5FDCFF"/>
+<rect x="33.8821" width="8.47059" height="59.2941" fill="#5FDCFF"/>
+<rect x="50.8237" width="8.47059" height="59.2941" fill="#5FDCFF"/>
+</svg>


### PR DESCRIPTION
README was showing the old Buf logo. This updates to the new one.