### PR TITLE
Fix pyproject license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "hatchling.build"
 name = "protovalidate"
 description = "Protocol Buffer Validation for Python"
 readme = "README.md"
-license-expression = "Apache 2.0"
-license-file = "LICENSE"
+license = "Apache 2.0"
+license-files = ["LICENSE"]
 keywords = ["validate", "protobuf", "protocol buffer"]
 requires-python = ">=3.9"
 classifiers = [


### PR DESCRIPTION
These parse out into core metadata `License` and `License-Expression` fields.

Ref: https://packaging.python.org/en/latest/specifications/pyproject-toml/#license