### PR TITLE
Set up trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,12 +29,13 @@ jobs:
           path: dist/
 
   publish:
-    # TODO: trusted publisher
-    # https://docs.astral.sh/uv/guides/publish/#publishing-your-package
     name: Publish on PyPI
     runs-on: ubuntu-latest
     environment:
       name: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     needs: build
     steps:
       - name: Checkout source
@@ -50,5 +51,3 @@ jobs:
 
       - name: Publish on PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
I've added a [trusted publisher][1] to our PyPI org. This just completes the process, following the step below.

Ref: https://docs.pypi.org/trusted-publishers/using-a-publisher/#github-actions

[1]: https://docs.pypi.org/trusted-publishers/adding-a-publisher/