### PR TITLE
Attempt fix for uv Dependabot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { fallback_version = "0.0.0" }
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
We're failing to run Dependabot for uv dependencies:

https://github.com/bufbuild/protovalidate-python/actions/runs/16629514901/job/47054963334

I found a fix for this issue, here:

https://github.com/dependabot/dependabot-core/issues/12340#issuecomment-3000630760

Makes me nervous that a stray release could end up with a 0.0.0 version, but we could just yank it - hopefully the upstream bug is fixed soon.

Ref: https://setuptools-scm.readthedocs.io/en/latest/config/#configuration-parameters

I'm making a [similar fix for connect-python][1].

[1]: https://github.com/connectrpc/connect-python/pull/30