### PR TITLE
Fix typo in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Format
         run: make format
       # When running with matrix.resolution == highest, we expect uv.lock to change, but we don't want that file checked in.
-      - if: matrix.resolution == 'higest'
+      - if: matrix.resolution == 'lowest-direct'
         name: Check generated
         run: make checkgenerate
         env:


### PR DESCRIPTION
This meant that we weren't running `make checkgenerate` in either step :facepalm:. Fixes it so it'll just run when using the default lowest-direct resolution.