### PR TITLE
Update package name from 'protovalidate-python' to 'protovalidate' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ message User {
 }
 ```
 
-Once you've added `protovalidate-python` to your project, validation is idiomatic Python:
+Once you've added `protovalidate` to your project, validation is idiomatic Python:
 
 ```python
 try:


### PR DESCRIPTION
The PyPI package is called `protovalidate`, this is confusing`(protovalidate-python` is the name of the repo)