### PR TITLE
Skip {types-,}protobuf upgrades in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,17 @@
       "enabled": false
     },
     {
+      "matchCategories": ["python"],
+      "matchPackageNames": [
+        "protobuf",
+        "types-protobuf"
+      ],
+      // We manage these dependencies ourselves.
+      "lockFileMaintenance": {
+        "enabled": false
+      }
+    },
+    {
       "matchCategories": [
         "python"
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,9 +37,7 @@
         "types-protobuf"
       ],
       // We manage these dependencies ourselves.
-      "lockFileMaintenance": {
-        "enabled": false
-      }
+      "enabled": false
     },
     {
       "matchCategories": [


### PR DESCRIPTION
We [previously ignored these in Dependabot][1]; should do the same in Renovate. #451 is failing because it's attempting to bump these.

Not entirely sure on the syntax here; I'm trying to follow the connect-python approach with otel: https://github.com/connectrpc/connect-python/blob/f188e7d0452be8a1ad04e308754852c76ee62c4d/renovate.json#L31-L37.

[1]: https://github.com/bufbuild/protovalidate-python/commit/328d768c7197b490d5e2263c0f55a53847169ad6#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-L14