### PR TITLE
Add release.yaml

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -4,4 +4,3 @@ changelog:
       - ignore-for-release
     authors:
       - renovate[bot]
-      - dependabot[bot]

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,7 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - renovate[bot]
+      - dependabot[bot]


### PR DESCRIPTION
This adds a `release.yml` file to remove dependabot / renovate PRs from auto-generated release notes.