### PR TITLE
Add VSCode workspace

### DIFF
--- a/protovalidate-python.code-workspace
+++ b/protovalidate-python.code-workspace
@@ -1,0 +1,50 @@
+{
+  "folders": [
+    {
+      "name": "/",
+      "path": ".",
+    },
+  ],
+  "extensions": {
+    "recommendations": [
+      "bufbuild.vscode-buf",
+      "charliermarsh.ruff",
+      "esbenp.prettier-vscode",
+      "github.vscode-github-actions",
+      "ms-python.python",
+      "ms-python.vscode-pylance",
+      "tombi-toml.tombi",
+    ],
+  },
+  "settings": {
+    "editor.formatOnSave": true,
+    "files.insertFinalNewline": true,
+    "python.analysis.typeCheckingMode": "basic",
+    "python.defaultInterpreterPath": "${workspaceFolder:/}/.venv/bin/python",
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": ["test"],
+    "python.testing.unittestEnabled": false,
+    "[github-actions-workflow]": {
+      "editor.formatOnSave": true,
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+    "debugpy.debugJustMyCode": false,
+    "[python]": {
+      "editor.formatOnSave": true,
+      "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit",
+        "source.organizeImports": "explicit",
+      },
+      "editor.defaultFormatter": "charliermarsh.ruff",
+    },
+    "[json][jsonc]": {
+      "editor.formatOnSave": true,
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+    "yaml.format.enable": false,
+    "[yaml]": {
+      "editor.formatOnSave": true,
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+  },
+}


### PR DESCRIPTION
Same as protobuf-py, we've been using this to make it easy to get started, without intruding on users of other IDEs. Notably, IDE tests become runnable without configuration