### PR TITLE
Run conformance tests via pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync
       - run: uv run poe test
-      - run: uv run poe test-conformance
 
   lint:
     runs-on: ubuntu-latest

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -1,8 +1,5 @@
 #:schema https://json.schemastore.org/partial-poe.json
 
-[env]
-PROTOVALIDATE_VERSION.default = "v1.2.0"
-
 [tasks.add-license-header]
 help = "Add license header to all source files"
 cmd = """
@@ -28,8 +25,6 @@ help = "Run code checks"
 sequence = [
   "lint",
   "test",
-  "test-conformance",
-  "test-conformance-legacy",
 ]
 
 [tasks.diffcheck]
@@ -49,7 +44,7 @@ sequence = [
 script = "scripts.generate_cel:main"
 
 [tasks.generate-protovalidate]
-script = "scripts.generate_protovalidate:main(environ['PROTOVALIDATE_VERSION'])"
+script = "scripts.generate_protovalidate:main"
 
 [tasks.generate-test]
 sequence = [
@@ -115,27 +110,6 @@ sequence = [
   { cmd = "tombi format --check" },
   { cmd = "tombi lint" },
 ]
-
-[tasks.test-conformance]
-help = "Run the CEL conformance tests"
-cmd = """
-go run github.com/bufbuild/protovalidate/tools/protovalidate-conformance@${PROTOVALIDATE_VERSION}
-    --strict_message
-    --expected_failures=test/conformance/nonconforming.yaml
-    --timeout 10s
-    python -- -m test.conformance.runner
-"""
-
-[tasks.test-conformance-legacy]
-help = "Run the CEL conformance tests through the legacy google.protobuf message path"
-env = { PROTOVALIDATE_CONFORMANCE_LEGACY = "1" }
-cmd = """
-go run github.com/bufbuild/protovalidate/tools/protovalidate-conformance@${PROTOVALIDATE_VERSION}
-    --strict_message
-    --expected_failures=test/conformance/nonconforming.yaml
-    --timeout 10s
-    python -- -m test.conformance.runner
-"""
 
 [tasks.test]
 help = "Run unit tests"

--- a/scripts/generate_cel.py
+++ b/scripts/generate_cel.py
@@ -19,7 +19,7 @@ from urllib.request import urlopen
 
 from fix_protobuf_imports.fix_protobuf_imports import fix_protobuf_imports
 
-from test.test_format import CEL_SPEC_VERSION
+from test.versions import CEL_SPEC_VERSION
 
 test_dir = Path(__file__).parent.parent / "test"
 

--- a/scripts/generate_protovalidate.py
+++ b/scripts/generate_protovalidate.py
@@ -21,17 +21,16 @@ from test.versions import PROTOVALIDATE_VERSION
 
 
 def main() -> None:
-    version = PROTOVALIDATE_VERSION
-    if re.match(r"^v\d+\.\d+\.\d+(\-.+)?$", version):
+    if re.match(r"^v\d+\.\d+\.\d+(\-.+)?$", PROTOVALIDATE_VERSION):
         # Version tag, fetch from BSR
-        protovalidate_path = f"buf.build/bufbuild/protovalidate:{version}"
-        protovalidate_testing_path = f"buf.build/bufbuild/protovalidate-testing:{version}"
+        protovalidate_path = f"buf.build/bufbuild/protovalidate:{PROTOVALIDATE_VERSION}"
+        protovalidate_testing_path = f"buf.build/bufbuild/protovalidate-testing:{PROTOVALIDATE_VERSION}"
     else:
         # Not a tag, generally an unreleased commit, fetch directly from git
-        protovalidate_path = f"https://github.com/bufbuild/protovalidate.git#subdir=proto/protovalidate,ref={version}"
-        protovalidate_testing_path = (
-            f"https://github.com/bufbuild/protovalidate.git#subdir=proto/protovalidate-testing,ref={version}"
+        protovalidate_path = (
+            f"https://github.com/bufbuild/protovalidate.git#subdir=proto/protovalidate,ref={PROTOVALIDATE_VERSION}"
         )
+        protovalidate_testing_path = f"https://github.com/bufbuild/protovalidate.git#subdir=proto/protovalidate-testing,ref={PROTOVALIDATE_VERSION}"
 
     repo = Path(__file__).parent.parent
 

--- a/scripts/generate_protovalidate.py
+++ b/scripts/generate_protovalidate.py
@@ -17,8 +17,11 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from test.versions import PROTOVALIDATE_VERSION
 
-def main(version: str) -> None:
+
+def main() -> None:
+    version = PROTOVALIDATE_VERSION
     if re.match(r"^v\d+\.\d+\.\d+(\-.+)?$", version):
         # Version tag, fetch from BSR
         protovalidate_path = f"buf.build/bufbuild/protovalidate:{version}"

--- a/test/conformance/test_conformance.py
+++ b/test/conformance/test_conformance.py
@@ -1,0 +1,77 @@
+# Copyright 2023-2026 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from test.versions import PROTOVALIDATE_VERSION
+
+
+def maybe_patch_args_with_debug(args: list[str]) -> list[str]:
+    # Do a best effort to invoke the child with debugging.
+    # This invokes internal methods from bundles provided by the IDE
+    # and may not always work.
+    try:
+        from pydevd import (  # ty: ignore[unresolved-import] - provided by IDE  # pyright: ignore[reportMissingImports] # noqa: PLC0415
+            _pydev_bundle,
+        )
+
+        return _pydev_bundle.pydev_monkey.patch_args(args)
+    except Exception:
+        return args
+
+
+@pytest.mark.parametrize("legacy", [False, True], ids=["py", "legacy"])
+def test_conformance(*, legacy: bool) -> None:
+    # Workaround pydevd monkeypatching of -m invocation not being compatible
+    # with Python 3.14 yet by executing a script that uses runpy itself.
+    # pydevd does monkeypatch -c form correctly.
+    script = dedent(
+        """
+        import runpy
+        runpy.run_module(
+            'test.conformance.runner',
+            run_name='__main__',
+            alter_sys=True
+        )
+        """
+    )
+    command = [sys.executable, "--", "-c", script]
+    command = maybe_patch_args_with_debug(command)
+
+    env = os.environ.copy()
+    if legacy:
+        env["PROTOVALIDATE_CONFORMANCE_LEGACY"] = "1"
+
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "go",
+            "run",
+            f"github.com/bufbuild/protovalidate/tools/protovalidate-conformance@{PROTOVALIDATE_VERSION}",
+            "--strict_message",
+            f"--expected_failures={Path(__file__).parent / 'nonconforming.yaml'}",
+            "--timeout",
+            "10s",
+            *command,
+        ],
+        env=env,
+        check=True,
+    )

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -27,9 +27,7 @@ from protovalidate.internal.cel_field_presence import InterpretedRunner
 
 from .gen.cel.expr import eval_pb2
 from .gen.cel.expr.conformance.test import simple_pb2
-
-# Version of the cel-spec that this implementation is conformant with.
-CEL_SPEC_VERSION = "v0.25.1"
+from .versions import CEL_SPEC_VERSION
 
 skipped_tests = [
     # cel-python seems to have a bug with ints and booleans in the same map which evaluate to the same value

--- a/test/versions.py
+++ b/test/versions.py
@@ -1,0 +1,21 @@
+# Copyright 2023-2026 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+# Version of the cel-spec that this implementation is conformant with.
+CEL_SPEC_VERSION = os.getenv("CEL_SPEC_VERSION", "v0.25.1")
+
+# Version of protovalidate this implementation targets.
+PROTOVALIDATE_VERSION = os.getenv("PROTOVALIDATE_VERSION", "v1.2.0")


### PR DESCRIPTION
Similar [setup](https://github.com/bufbuild/protobuf-py/blob/main/tests/conformance/test_conformance.py) to protobuf-py where we invoke conformance from a pytest test to make it easy to run from IDE, and allow us to support IDE debugging.