### PR TITLE
Use uv build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "protovalidate"
+version = "2.0.0"
 description = "Protocol Buffer Validation for Python"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -28,7 +29,6 @@ dependencies = [
   "google-re2>=1.1; python_version == '3.12'",
   "protobuf-py>=0.1.1",
 ]
-dynamic = ["version"]
 
 [project.urls]
 Documentation = "https://protovalidate.com"
@@ -66,12 +66,8 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatch-vcs", "hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.version]
-source = "vcs"
-raw-options = { fallback_version = "0.0.0" }
+requires = ["uv_build>=0.11.2,<0.12"]
+build-backend = "uv_build"
 
 ## License headers
 [tool.licenseheader]
@@ -165,3 +161,7 @@ split-on-trailing-comma = false
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.uv.build-backend]
+module-name = "protovalidate"
+module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -96,7 +96,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -402,6 +402,7 @@ wheels = [
 
 [[package]]
 name = "protovalidate"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cel-python" },


### PR DESCRIPTION
We use uv build in all the other projects so this consolidates on it.

It also prepares the next version as v2 since the public API change (returning protobuf-py protos instead of google.protobuf) should warrant it I think.